### PR TITLE
persist event arguments for each call

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,18 @@ obj.InvokeEvent();
 
 hook.Verify(Called.AtMost(2));
 ```
+
+### Never Raised
+
+```cs
+using EventTesting;
+
+var obj = new TestObject();
+
+var hook = EventHook.For(obj)
+    .HookOnly((o, h) => o.OnTest += h);
+
+obj.DoNotInvokeEvent();
+
+hook.Verify(Called.Never());
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Event Testing [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Build status](https://ci.appveyor.com/api/projects/status/0wckkllo1i5n8c49?svg=true)](https://ci.appveyor.com/project/f-tischler/eventtesting) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=f-tischler_EventTesting&metric=alert_status)](https://sonarcloud.io/dashboard?id=f-tischler_EventTesting)
 
-Writing test code for event-driven APIs in C# involves a lot of boiler plate code which obfuscates tests. This library intents to alleviate this problem by provding a fluent programming model for verifying event invocations and valdidating event arguments. It also supports use cases where events may be fired asynchonously with some delay by allowing to specify a timeout for the invocation verification.
+Writing test code for event-driven APIs in C# involves a lot of boiler plate code which obfuscates tests. This library intents to alleviate this problem by provding a fluent programming model for verifying event invocations and validating event arguments. It also supports use cases where events may be fired asynchonously with some delay by allowing to specify a timeout for the invocation verification.
 
 # Installation
 
@@ -38,6 +38,21 @@ hook.Verify(Called.Twice());
 Verification is implemented using the `EventTesting.IVerifier` interface and can be extended with custom verifiers. For the most common use cases there are implementations in the `EventTesting.Verifiers` namespace. 
 
 The class `EventTesting.Called` provides a simplified interface for creating verifiers to build a more fluent API.
+
+In case you have multiple events being fired winthin a call, a list of event arguments `EventHook<T, TEventArgs>.CallsEventArgs` is saved.
+
+```cs
+var hook = EventHook.For(obj)
+    .HookOnly<TestEventArgs>((o, h) => o.OnTest += h) as EventHook<TestObject, TestEventArgs>;
+    // or .Hook<TestEventArgs>((o, h) => o.OnTest += h).Build() as EventHook<TestObject, TestEventArgs>
+
+o.InvokeComplexCustomArgEvent(new TestEventArgs("event #99"));
+o.InvokeComplexCustomArgEvent(new TestEventArgs("event #0"));
+
+Assert.AreEqual(2, hook.CallsEventArgs.Count);
+Assert.AreEqual("event #99", hook.CallsEventArgs[0].Arg);
+Assert.AreEqual("event #0", hook.CallsEventArgs[1].Arg);
+```
 
 ## Argument Verification
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Verification is implemented using the `EventTesting.IVerifier` interface and can
 
 The class `EventTesting.Called` provides a simplified interface for creating verifiers to build a more fluent API.
 
-In case you have multiple events being fired winthin a call, a list of event arguments `EventHook<T, TEventArgs>.CallsEventArgs` is saved.
+In case you have multiple events being fired within a call, a list of event arguments `EventHook<T, TEventArgs>.CallsEventArgs` is saved.
 
 ```cs
 var hook = EventHook.For(obj)

--- a/src/EventTesting/Called.cs
+++ b/src/EventTesting/Called.cs
@@ -12,6 +12,11 @@ namespace EventTesting
             return new ExactVerifier(times);
         }
 
+        public static IVerifier Never()
+        {
+            return Exactly(0);
+        }
+
         public static IVerifier Once()
         {
             return Exactly(1);

--- a/src/EventTesting/EventHook.cs
+++ b/src/EventTesting/EventHook.cs
@@ -35,7 +35,7 @@ namespace EventTesting
                 await Task.Delay(TimeSpan.FromMilliseconds(50));
         }
 
-        public void Reset()
+        public virtual void Reset()
         {
             Calls = 0;
         }
@@ -46,8 +46,16 @@ namespace EventTesting
         }
     }
 
-    internal class EventHook<T, TEventArgs> : EventHook
+    public class EventHook<T, TEventArgs> : EventHook, IEventHook<T, TEventArgs>
     {
+        public List<TEventArgs> CallsEventArgs { get; protected set; } = new List<TEventArgs>();
+
+        public override void Reset()
+        {
+            CallsEventArgs.Clear();
+            base.Reset();
+        }
+
         internal void SetEventName(string eventName)
         {
             EventName = eventName;
@@ -61,6 +69,7 @@ namespace EventTesting
         internal void HandleEvent(object o, TEventArgs e)
         {
             ++Calls;
+            CallsEventArgs.Add(e);
 
             var i = 0;
 

--- a/src/EventTesting/IEventHook.cs
+++ b/src/EventTesting/IEventHook.cs
@@ -1,9 +1,16 @@
-﻿namespace EventTesting
+﻿using System.Collections.Generic;
+
+namespace EventTesting
 {
     public interface IEventHook
     {
         string EventName { get; }
 
         int Calls { get; }
+    }
+
+    public interface IEventHook<T, TEventArgs>
+    {
+        List<TEventArgs> CallsEventArgs { get; }
     }
 }


### PR DESCRIPTION
in case you have multiple events being fired within a call, this change will persist the list of event arguments for each call, in the order they are handled.